### PR TITLE
Update docs and example for dfuse 0.3.0 when providing WebSocket clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ of `WebSocket` client, like the one provided by the [ws](https://npmjs.com/packa
 package.
 
 If none is provided, the library throw an error. To avoid this error, you should pass
-the `streamClientOptions.socketOptions.webSocketFactory` option when creating the dfuse
+the `streamClientOptions.socketOptions.webSocketFactory` and the
+`graphqlStreamClientOptions.socketOptions.webSocketFactory` options when creating the dfuse
 Client. This factory method receives the full url to connect to the remote endpoint
 (this will include the API token to use in query parameters of the url) and should
 return a valid `WebSocket` client object.


### PR DESCRIPTION
### Issue
Since version `0.3.0`, the dfuse client creates a `GraphqlStreamClient` (see https://github.com/dfuse-io/client-js/blob/v0.3.0/src/client/client.ts#L258). This behavior did not exist before and developers that have chosen to not pollute the global scope will find themselves with the runtime error:

> You did not provide a `webSocket` option and we were not able find a `WebSocket` object in the global scope to create use.

This is because the `StreamClient` will have its own WebSocket factory option provided via `streamClientOptions.socketOptions.webSocketFactory` but the `GraphqlStreamClient` will have none.

### How to Reproduce
To reproduce this issue, simply follow the [Example instructions](https://github.com/dfuse-io/client-js#examples) and run the `nodejs-fetch-and-websocket-options.ts` example from the `master` branch:

```sh
yarn run:example examples/advanced/nodejs-fetch-and-websocket-options.ts
```

### The docs fix
This PR updates the above-mentioned example and the README to reflect the new changes introduced with version `0.3.0`: simply provide the WebSocket factory to `graphqlStreamClientOptions.socketOptions.webSocketFactory` in addition to the already mentioned `streamClientOptions`.


### Alternatives?
An option would be to restructure the `DfuseClientOptions` interface to accept a `WebSocketFactory` property so that any client that requires a WebSocket can use the provided one (or, when `undefined`, fallback to inferring from the global scope) as opposed of providing it manually for every client that you may or may not even use.