### PR TITLE
Recommend client-side friendly modules

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -76,7 +76,7 @@ const client = createDfuseClient({
 
 If you are in a Node.js environment, you will have to provide
 a `fetch` compatible function an a `WebSocket` client. We suggest
-the `unfetch` and `ws` libraries. For a quick configuration path,
+the [`unfetch`](https://ghub.io/unfetch) and [`isomorphic-ws`](https://ghub.io/isomorphic-ws) libraries. For a quick configuration path,
 simply define the following on the global scope:
 
 ```js

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -76,12 +76,12 @@ const client = createDfuseClient({
 
 If you are in a Node.js environment, you will have to provide
 a `fetch` compatible function an a `WebSocket` client. We suggest
-the `node-fetch` and `ws` libraries. For a quick configuration path,
+the `unfetch` and `ws` libraries. For a quick configuration path,
 simply define the following on the global scope:
 
 ```js
-global.fetch = require("node-fetch")
-global.WebSocket = require("ws")
+global.fetch = require("unfetch")
+global.WebSocket = require("isomorphic-ws")
 ```
 
 **Note** Don't forget to add those libraries to your package if

--- a/README.md
+++ b/README.md
@@ -113,18 +113,18 @@ they are picked automatically by the library. While polluting the global scope, 
 easiest way to get started.
 
 It's what the examples in this project do using respectively
-[node-fetch](https://www.npmjs.com/package/node-fetch) and
+[unfetch](https://www.npmjs.com/package/unfetch) and
 and [ws](https://www.npmjs.com/package/ws) for `fetch` and `WebSocket` respectively.
 
 Installation instructions using Yarn would be:
 
-    yarn add node-fetch ws
+    yarn add unfetch ws
 
 In the bootstrap phase of your application, prior doing any `@dfuse/client` imports/require,
 put the following code:
 
-    global.fetch = require("node-fetch");
-    global.WebSocket = require("ws");
+    global.fetch = require("unfetch");
+    global.WebSocket = require("isomorphic-ws");
 
 You can check the [Node.js Configuration](./examples/advanced/nodejs-fetch-and-websocket-options.ts)
 example for how to avoid polluting the global scope.
@@ -143,7 +143,7 @@ a function).
 
 If `window.fetch` is undefined, we fallback to check `global.fetch` variable.
 This can be set in a Node.js environment to point to a compatible implementation
-of `fetch`, like the one provided by the [node-fetch](https://npmjs.com/package/node-fetch)
+of `fetch`, like the one provided by the [unfetch](https://npmjs.com/package/unfetch)
 package.
 
 If none is provided, the library throw an error. To avoid this error, you should pass

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ they are picked automatically by the library. While polluting the global scope, 
 easiest way to get started.
 
 It's what the examples in this project do using respectively
-[unfetch](https://www.npmjs.com/package/unfetch) and
-and [ws](https://www.npmjs.com/package/ws) for `fetch` and `WebSocket` respectively.
+[unfetch](https://ghub.io/unfetch) and
+and [isomorphickws](https://ghub.io/isomorphic-ws) for `fetch` and `WebSocket` respectively.
 
 Installation instructions using Yarn would be:
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ easiest way to get started.
 
 It's what the examples in this project do using respectively
 [unfetch](https://ghub.io/unfetch) and
-and [isomorphickws](https://ghub.io/isomorphic-ws) for `fetch` and `WebSocket` respectively.
+and [isomorphic-ws](https://ghub.io/isomorphic-ws) for `fetch` and `WebSocket` respectively.
 
 Installation instructions using Yarn would be:
 
@@ -163,7 +163,7 @@ In the Browser environment, this is the standard `WebSocket` variable that is us
 
 If `window.WebSocket` is undefined, we fallback to check `global.WebSocket` variable.
 This can be set in a Node.js environment to point to a compatible implementation
-of `WebSocket` client, like the one provided by the [ws](https://npmjs.com/package/ws)
+of `WebSocket` client, like the one provided by the [isomorphic-ws](https://ghub.io/isomorphic-ws)
 package.
 
 If none is provided, the library throw an error. To avoid this error, you should pass
@@ -173,7 +173,7 @@ Client. This factory method receives the full url to connect to the remote endpo
 (this will include the API token to use in query parameters of the url) and should
 return a valid `WebSocket` client object.
 
-We highly suggest to use [ws](https://npmjs.com/package/ws) package straight in a
+We highly suggest to use [isomorphic-ws](https://ghub.io/isomorphic-ws) package straight in a
 Node.js environment.
 
 #### API Token Store

--- a/examples/advanced/nodejs-fetch-and-websocket-options.ts
+++ b/examples/advanced/nodejs-fetch-and-websocket-options.ts
@@ -17,8 +17,8 @@ import { IncomingMessage } from "http"
 
 // We add the example imports here to make the example clearer, in your
 // own code, group them with yours.
-import nodeFetch from "node-fetch"
-import WebSocketClient from "ws"
+import nodeFetch from "unfetch"
+import WebSocketClient from "isomorphic-ws"
 
 async function main() {
   const client = createDfuseClient({

--- a/examples/config.ts
+++ b/examples/config.ts
@@ -30,8 +30,8 @@ if (process.env.DEBUG_LEAKED_HANDLES) {
 // Check [Configure Node.js](https://github.com/dfuse-io/client/blob/master/README.md#node-js)
 // section of the read me for further explanation around this topic.
 //
-;(global as any).fetch = require("node-fetch")
-;(global as any).WebSocket = require("ws")
+;(global as any).fetch = require("unfetch")
+;(global as any).WebSocket = require("isomorphic-ws")
 
 // You don't require to have this configuration and the associated import
 // in your own project (of course, feel free to copy it if you think it helps).

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "jest-expect-message": "^1.0.2",
     "leaked-handles": "^5.2.0",
     "lint-staged": "^7.3.0",
-    "node-fetch": "^2.3.0",
     "patch-package": "^6.0.7",
     "postinstall-postinstall": "^2.0.0",
     "prettier": "^1.14.3",
@@ -96,11 +95,12 @@
     "typedoc": "^0.14.2",
     "typedoc-default-themes-extension": "^0.0.3",
     "typedoc-plugin-toc-group": "^0.0.4",
-    "typescript": "^3.6.3",
-    "ws": "^7.0.1"
+    "typescript": "^3.6.3"
   },
   "dependencies": {
     "@types/debug": "^0.0.31",
-    "debug": "^4.1.0"
+    "debug": "^4.1.0",
+    "isomorphic-ws": "^4.0.1",
+    "unfetch": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,8 +63,6 @@
     "@types/dotenv": "^4.0.3",
     "@types/jest": "^23.3.9",
     "@types/jest-expect-message": "^1.0.0",
-    "@types/node-fetch": "^2.1.6",
-    "@types/ws": "^6.0.1",
     "dotenv": "^6.1.0",
     "graphql": "^14.5.3",
     "graphql-tag": "^2.10.1",

--- a/src/client/__tests__/socket.test.ts
+++ b/src/client/__tests__/socket.test.ts
@@ -1,10 +1,7 @@
 import { createSocket } from "../socket"
 import { InboundMessage, InboundMessageType } from "../../message/inbound"
 import { getActionTracesMessage } from "../../message/outbound"
-import { WebSocketFactory } from "../../types/socket"
-import { CLOSED } from "ws"
 import { MockSocket, MockWebSocket } from "./mocks"
-import { doesNotReject } from "assert"
 import { Deferred } from "../../helpers/promises"
 
 describe("socket", () => {

--- a/src/client/socket.ts
+++ b/src/client/socket.ts
@@ -116,7 +116,7 @@ export interface SocketOptions {
    * **Important Note**<br><br>
    * The actual `event` object you will receive is different wheter you use
    * the Browser `WebSocket` instance ([ErrorEvent](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event))
-   * or depending on the Node.js library you use (If you use [ws](https://www.npmjs.com/package/ws) package, then it's
+   * or depending on the Node.js library you use (If you use [isomorphic-ws](https://ghub.io/isomorphic-ws) package, then it's
    * [ErrorEvent](https://github.com/websockets/ws/blob/master/lib/event-target.js#L87))
    *
    * @default `() => {}` (noop)
@@ -134,7 +134,7 @@ export interface SocketOptions {
    * **Important Note**<br><br>
    * The actual `event` object you will receive is different wheter you use
    * the Browser `WebSocket` instance ([CloseEvent](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close_event))
-   * or depending on the Node.js library you use (If you use [ws](https://www.npmjs.com/package/ws) package, then it's
+   * or depending on the Node.js library you use (If you use [isomorphic-ws](https://ghub.io/isomorphic-ws) package, then it's
    * [CloseEvent](https://github.com/websockets/ws/blob/master/lib/event-target.js#L47))
    *
    * @default `() => {}` (noop)

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,7 +662,7 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async-limiter@^1.0.0, async-limiter@~1.0.0:
+async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
@@ -2284,6 +2284,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -3298,11 +3303,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4842,6 +4842,11 @@ uglify-js@^3.1.4:
     commander "~2.20.3"
     source-map "~0.6.1"
 
+unfetch@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
+  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -5078,13 +5083,6 @@ ws@^5.2.0:
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
   dependencies:
     async-limiter "~1.0.0"
-
-ws@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.0.1.tgz#1a04e86cc3a57c03783f4910fdb090cf31b8e165"
-  integrity sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==
-  dependencies:
-    async-limiter "^1.0.0"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,13 +414,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node-fetch@^2.1.6":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.3.2.tgz#e01893b176c6fa1367743726380d65bce5d6576b"
-  integrity sha512-yW0EOebSsQme9yKu09XbdDfle4/SmWZMK4dfteWcSLCYNQQcF+YOv0kIrvm+9pO11/ghA4E6A+RNQqvYj4Nr3A==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "11.13.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
@@ -445,13 +438,6 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
-"@types/ws@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"
-  dependencies:
-    "@types/events" "*"
-    "@types/node" "*"
 
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.12"


### PR DESCRIPTION
✨ This PR does not change the library usage in any way, it's strictly bug prevention. ✨ 

<p align="center">
  <img src="https://avatars2.githubusercontent.com/u/37049750?s=200&v=4">
</p>
<p align="center">
    <b>A PR from the team at Everipedia</b>
</p>

## Replace all node-only packages with isomorphic packages

I'll begin by saying that if we had done this last week, this would have saved ~2 developer days.

* If users accidentally included server-side modules in their client-side code, webpack will bundle in a **large** amount of backend-specific utilities in-order for the library to work. And in-the-end, these modified libraries still don't work properly. (`node-fetch` causes errors [like this](https://sentry.io/share/issue/3f451871007b48b3a80ae123f18486bb/))

Or these: 
![image](https://user-images.githubusercontent.com/3408480/79377385-96496300-7f29-11ea-8a9f-3c315b9cc264.png)

* The two packages I'm recommending instead will properly exclude the backend utilities if bundled for client-side. In addition to the bug mentioning above, this **reduced our bundle at Everipdia over 2.3MB**


