### PR TITLE
Added a NOOP token manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 # Yarn
 yarn-error.log
 node_modules/
+
+# Webstorm
+.idea

--- a/src/client/__tests__/api-token-manager.test.ts
+++ b/src/client/__tests__/api-token-manager.test.ts
@@ -1,4 +1,9 @@
-import { ApiTokenManager, createApiTokenManager, isApiTokenExpired } from "../api-token-manager"
+import {
+  ApiTokenManager,
+  createApiTokenManager,
+  createNoopApiTokenManager,
+  isApiTokenExpired
+} from "../api-token-manager"
 import { MockApiTokenStore, MockRefreshScheduler, mock } from "./mocks"
 import { ApiTokenInfo } from "../../types/auth-token"
 
@@ -11,6 +16,7 @@ const nonExpiredJustBeforeApiTokenInfo = { token: "non-expired-just-before", exp
 const expiredTokenInfo = { token: "expired-far", expires_at: 100 }
 const expiredRightOnApiTokenInfo = { token: "expired-right-on", expires_at: 1000 }
 const expiredJustAfterApiTokenInfo = { token: "expired-just-after", expires_at: 999 }
+const noopApiTokenInfo = { token: "aa.bb.cc", expires_at: 0 }
 
 const defaultFetchApiTokenInfo = nonExpiredApiTokenInfo
 
@@ -155,6 +161,21 @@ describe("ApiTokenManager", () => {
     manager.release()
     expect(apiTokenStore.releaseMock).toHaveBeenCalledTimes(1)
     expect(refreshScheduler.releaseMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("NoopApiTokenManager", () => {
+  let manager: ApiTokenManager
+
+  beforeEach(() => {
+    spyOn(Date, "now").and.returnValue(currentDate)
+
+    manager = createNoopApiTokenManager("aa.bb.cc")
+  })
+
+  it("should return hardwired token", async () => {
+    const result = await manager.getTokenInfo()
+    expect(result).toEqual(noopApiTokenInfo)
   })
 })
 

--- a/src/client/api-token-manager.ts
+++ b/src/client/api-token-manager.ts
@@ -42,6 +42,26 @@ export function createApiTokenManager(
 }
 
 /**
+ * This is the authentication URL that will be reach to issue
+ * new API token.
+ *
+ * @default `https://auth.dfuse.io`
+ */
+
+/**
+ * Create the Noop [[ApiTokenManager]] interface that will manage all the lifecycle
+ * of a token.
+ *
+ * @param token The hardwired token value,
+ *        @default `a.b.c`
+ *
+ * @kind Factories
+ */
+export function createNoopApiTokenManager(token: string): ApiTokenManager {
+  return new NoopApiTokenManager(token)
+}
+
+/**
  * Check wheter the received [[ApiTokenInfo]] parameter is expired or near its
  * expiration.
  */
@@ -159,5 +179,25 @@ class DefaultApiTokenManager implements ApiTokenManager {
     })
 
     return this.fetchTokenPromise
+  }
+}
+
+class NoopApiTokenManager implements ApiTokenManager {
+  private token: string
+  private expiresAt: number
+  private debug: IDebugger
+
+  constructor(token: string) {
+    this.token = token || "a.b.c"
+    this.expiresAt = 0
+    this.debug = debugFactory("dfuse:token-manager-noop")
+  }
+
+  public release(): void {
+    this.debug("Releasing default API token manager")
+  }
+
+  public async getTokenInfo(): Promise<ApiTokenInfo> {
+    return { token: this.token, expires_at: this.expiresAt }
   }
 }

--- a/src/client/api-token-manager.ts
+++ b/src/client/api-token-manager.ts
@@ -42,18 +42,10 @@ export function createApiTokenManager(
 }
 
 /**
- * This is the authentication URL that will be reach to issue
- * new API token.
- *
- * @default `https://auth.dfuse.io`
- */
-
-/**
  * Create the Noop [[ApiTokenManager]] interface that will manage all the lifecycle
  * of a token.
  *
- * @param token The hardwired token value,
- *        @default `a.b.c`
+ * @param token The hardwired token value (default value -> `a.b.c`)
  *
  * @kind Factories
  */

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -23,7 +23,11 @@ import {
   StatePermissionLinksResponse,
   StateTableRowResponse
 } from "../types/state"
-import { ApiTokenManager, createApiTokenManager } from "./api-token-manager"
+import {
+  ApiTokenManager,
+  createApiTokenManager,
+  createNoopApiTokenManager
+} from "./api-token-manager"
 import { createHttpClient, HttpClientOptions } from "./http-client"
 import {
   V1_AUTH_ISSUE,
@@ -397,13 +401,17 @@ export class DefaultClient implements DfuseClient {
     this.graphqlStreamClient = graphqlStreamClient
     this.requestIdGenerator = requestIdGenerator
 
-    this.apiTokenManager = createApiTokenManager(
-      () => this.authIssue(this.apiKey),
-      this.onTokenRefresh,
-      0.95,
-      apiTokenStore,
-      refreshScheduler
-    )
+    if (this.endpoints.authUrl.startsWith("null://")) {
+      this.apiTokenManager = createNoopApiTokenManager("a.b.c")
+    } else {
+      this.apiTokenManager = createApiTokenManager(
+        () => this.authIssue(this.apiKey),
+        this.onTokenRefresh,
+        0.95,
+        apiTokenStore,
+        refreshScheduler
+      )
+    }
   }
 
   public release(): void {


### PR DESCRIPTION
Added a noop token manager.  When the `dfuseClient` is configured with an `authUrl` equal to `null://....` it will use the noop token manager. The NOOP token manager returns a dummy token `a.b.c`.
