### PR TITLE
Disable the api key format inspection for non enterprise editions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Removed the api key prefix validation for non enterprise Dfuse editions.
+- Removed the api key prefix validation.
 
 ## 0.3.17 (October 20, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Removed the api key prefix validation for non enterprise Dfuse editions.
+
 ## 0.3.17 (October 20, 2020)
 
 - Fixed race condition when starting to start new streams (WebSocket or GraphQL over WebSocket) while the socket is currently

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -81,20 +81,6 @@ describe("DfuseClient", () => {
     }).not.toThrow()
   })
 
-  it("correctly checks API key (in createDfuseClient)", () => {
-    const triggerCheck = (): DfuseClient =>
-      createDfuseClient({ apiKey: "web_!!!!!!", network: "mainnet.eos.dfuse.io" })
-
-    expect(triggerCheck).toThrowError(DfuseError)
-    expect(triggerCheck).toThrowErrorMatchingInlineSnapshot(`
-      "The provided API key is not in the right format, expecting it
-      to start with either \`mobile_\`, \`server_\` or \`web_\` followed
-      by a series of hexadecimal character (i.e.) \`web_0123456789abcdef\`)
-
-      Input received: web_!!!!!!"
-    `)
-  })
-
   it("correctly checks API key when authentication is explicitely true (in createDfuseClient)", () => {
     const triggerCheck = (): DfuseClient =>
       createDfuseClient({
@@ -122,11 +108,7 @@ describe("DfuseClient", () => {
 
     expect(triggerCheck).toThrowError(DfuseError)
     expect(triggerCheck).toThrowErrorMatchingInlineSnapshot(`
-      "The provided API key is not in the right format, expecting it
-      to start with either \`mobile_\`, \`server_\` or \`web_\` followed
-      by a series of hexadecimal character (i.e.) \`web_0123456789abcdef\`)
-
-      It seems your providing directly a API token (JWT) instead
+      "It seems your providing directly a API token (JWT) instead
       of an API key and are using your previous authentication protocol.
       Please refer to http://docs.dfuse.io/#authentication for
       all the details about API key and how to generate an API token

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -257,9 +257,9 @@ let clientInstanceId = 0
  * @kind Factories
  */
 export function createDfuseClient(options: DfuseClientOptions): DfuseClient {
-  const endpoint = networkToEndpoint(options.network)
-  checkApiKey(options.apiKey, options.authentication, endpoint)
+  checkApiKey(options.apiKey, options.authentication)
 
+  const endpoint = networkToEndpoint(options.network)
   const secureEndpoint = options.secure === undefined ? true : options.secure
   const authentication = options.authentication === undefined ? true : options.authentication
 
@@ -305,11 +305,7 @@ export function createDfuseClient(options: DfuseClientOptions): DfuseClient {
 
 // Even though higher the type say it cannot be empty, this is usually provided
 // by the user and as such, as assume it could be undefined.
-function checkApiKey(
-  apiKey: string | undefined,
-  authentication: boolean | undefined,
-  endpoint: string
-): void {
+function checkApiKey(apiKey: string | undefined, authentication: boolean | undefined): void {
   if (authentication !== undefined && authentication === false) {
     return
   }
@@ -325,20 +321,9 @@ function checkApiKey(
     throw new DfuseError(messages.join("\n"))
   }
 
-  const messages: string[] = []
-
-  if (isEnterpriseEdition(endpoint) && !apiKey.match(/^(mobile|server|web)_[0-9a-f]{2,}/i)) {
-    messages.push(
-      "The provided API key is not in the right format, expecting it",
-      "to start with either `mobile_`, `server_` or `web_` followed",
-      "by a series of hexadecimal character (i.e.) `web_0123456789abcdef`)",
-      ""
-    )
-  }
-
   // Assume it's an API token if looks (roughly) like a JWT token
   if (apiKey.split(".").length === 3) {
-    messages.push(
+    const messages = [
       "It seems your providing directly a API token (JWT) instead",
       "of an API key and are using your previous authentication protocol.",
       "Please refer to http://docs.dfuse.io/#authentication for",
@@ -346,18 +331,12 @@ function checkApiKey(
       "from it.",
       "",
       "And you can visit https://app.dfuse.io to obtain your free API key",
-      ""
-    )
-  }
+      "",
+    ]
 
-  if (messages.length > 0) {
     messages.push(`Input received: ${apiKey}`)
     throw new DfuseError(messages.join("\n"))
   }
-}
-
-function isEnterpriseEdition(endpoint: string): boolean {
-  return endpoint.includes("dfuse.io")
 }
 
 function inferApiTokenStore(apiKey: string | undefined): ApiTokenStore {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -257,9 +257,9 @@ let clientInstanceId = 0
  * @kind Factories
  */
 export function createDfuseClient(options: DfuseClientOptions): DfuseClient {
-  checkApiKey(options.apiKey, options.authentication)
-
   const endpoint = networkToEndpoint(options.network)
+  checkApiKey(options.apiKey, options.authentication, endpoint)
+
   const secureEndpoint = options.secure === undefined ? true : options.secure
   const authentication = options.authentication === undefined ? true : options.authentication
 
@@ -305,7 +305,11 @@ export function createDfuseClient(options: DfuseClientOptions): DfuseClient {
 
 // Even though higher the type say it cannot be empty, this is usually provided
 // by the user and as such, as assume it could be undefined.
-function checkApiKey(apiKey: string | undefined, authentication: boolean | undefined): void {
+function checkApiKey(
+  apiKey: string | undefined,
+  authentication: boolean | undefined,
+  endpoint: string
+): void {
   if (authentication !== undefined && authentication === false) {
     return
   }
@@ -321,32 +325,39 @@ function checkApiKey(apiKey: string | undefined, authentication: boolean | undef
     throw new DfuseError(messages.join("\n"))
   }
 
-  if (!apiKey.match(/^(mobile|server|web)_[0-9a-f]{2,}/i)) {
-    const messages = [
+  const messages: string[] = []
+
+  if (isEnterpriseEdition(endpoint) && !apiKey.match(/^(mobile|server|web)_[0-9a-f]{2,}/i)) {
+    messages.push(
       "The provided API key is not in the right format, expecting it",
       "to start with either `mobile_`, `server_` or `web_` followed",
       "by a series of hexadecimal character (i.e.) `web_0123456789abcdef`)",
+      ""
+    )
+  }
+
+  // Assume it's an API token if looks (roughly) like a JWT token
+  if (apiKey.split(".").length === 3) {
+    messages.push(
+      "It seems your providing directly a API token (JWT) instead",
+      "of an API key and are using your previous authentication protocol.",
+      "Please refer to http://docs.dfuse.io/#authentication for",
+      "all the details about API key and how to generate an API token",
+      "from it.",
       "",
-    ]
+      "And you can visit https://app.dfuse.io to obtain your free API key",
+      ""
+    )
+  }
 
-    // Assume it's an API token if looks (roughly) like a JWT token
-    if (apiKey.split(".").length === 3) {
-      messages.push(
-        "It seems your providing directly a API token (JWT) instead",
-        "of an API key and are using your previous authentication protocol.",
-        "Please refer to http://docs.dfuse.io/#authentication for",
-        "all the details about API key and how to generate an API token",
-        "from it.",
-        "",
-        "And you can visit https://app.dfuse.io to obtain your free API key",
-        ""
-      )
-    }
-
+  if (messages.length > 0) {
     messages.push(`Input received: ${apiKey}`)
-
     throw new DfuseError(messages.join("\n"))
   }
+}
+
+function isEnterpriseEdition(endpoint: string): boolean {
+  return endpoint.includes("dfuse.io")
 }
 
 function inferApiTokenStore(apiKey: string | undefined): ApiTokenStore {


### PR DESCRIPTION
Basically disables the prefix check (`web_`, `server_`, ...) for all non enterprise dfuse editions.