### PR TITLE
Use .mjs extension for es5 build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "dfuse JavaScript/TypeScript Client Library (for [dfuse API](https://docs.dfuse.io/))",
   "sideEffects": false,
   "main": "dist/lib/index.js",
-  "module": "dist/dfuse-client.es5.js",
+  "module": "dist/dfuse-client.es5.mjs",
   "browser": "dist/dfuse-client.umd.js",
   "typings": "dist/types/index.d.ts",
   "files": [


### PR DESCRIPTION
This is needed to be able to include this package in apps that use [esbuild](https://esbuild.github.io/)